### PR TITLE
Disabled/Enabled stop/start buttons - Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,91 @@
 ﻿################################################################################
 # This .gitignore file was automatically created by Microsoft(R) Visual Studio.
 ################################################################################
+ 
+# Click-Once directory
+publish/
 
-/packages
-/SolrScheduler.GUI/bin/Debug
-/SolrScheduler.GUI/obj/Debug
-*.ncrunchproject
-/SolrScheduler.Interfaces/obj
-/SolrScheduler.Objects/obj
-/SolrScheduler.Objects.Tests/obj/Debug
+# Publish Web Output
+*.[Pp]ublish.xml
+*.azurePubxml
+# Note: Comment the next line if you want to checkin your web deploy settings,
+# but database connection strings (with potential passwords) will be unencrypted
+*.pubxml
+*.publishproj
+
+# Microsoft Azure Web App publish settings. Comment the next line if you want to
+# checkin your Azure Web App publish settings, but sensitive information contained
+# in these scripts will be unencrypted
+PublishScripts/
+
+# NuGet Packages
+*.nupkg
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/
+
+# Visual Studio 2017 auto generated files
+Generated\ Files/ 
+
+# Files built by Visual Studio
+*_i.c
+*_p.c
+*_i.h
+*.ilk
+*.meta
+*.obj
+*.pch
+*.pdb
+*.pgc
+*.pgd
+*.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp
+*.tmp_proj
+*.log
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+
+# User-specific files
+*.suo
 *.user
+*.userosscache
+*.sln.docstates
+
 *.DotSettings
-*.ncrunchsolution
+
 /SolrScheduler.sln.GhostDoc.xml
+
+# NCrunch
+_NCrunch_*
+.*crunch*.local.xml
+nCrunchTemp_*
+*.ncrunchsolution

--- a/SolrScheduler.GUI/Controls/SolrJobManagementPanel.xaml
+++ b/SolrScheduler.GUI/Controls/SolrJobManagementPanel.xaml
@@ -33,14 +33,14 @@
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <!-- ReSharper disable once Xaml.BindingWithContextNotResolved -->
-                            <Button Content="Start Job" CommandParameter="{Binding Mode=OneWay, Path=OperationModel.Name}" Click="StartJob_Click"></Button>
+                            <Button Content="Start Job" IsEnabled="{Binding Mode=OneWay, Path=IsStopped}" CommandParameter="{Binding Mode=OneWay, Path=OperationModel.Name}" Click="StartJob_Click"></Button>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn>
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <Button Content="Stop Job" CommandParameter="{Binding Mode=OneWay, Path=OperationModel.Name}" Click="StopJob_Click"></Button>
+                            <Button Content="Stop Job" IsEnabled="{Binding Mode=OneWay, Path=IsRunning}" CommandParameter="{Binding Mode=OneWay, Path=OperationModel.Name}" Click="StopJob_Click"></Button>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/SolrScheduler.Interfaces/Solr/ISolrOperation.cs
+++ b/SolrScheduler.Interfaces/Solr/ISolrOperation.cs
@@ -25,6 +25,12 @@ namespace SolrScheduler.Interfaces.Solr {
         bool IsRunning { get; }
 
         /// <summary>
+        /// Inverse of IsRunning - primarily used to disable button in WPF grid
+        /// </summary>
+        /// <value><c>true</c> if this instance is stopped; otherwise, <c>true</c>.</value>
+        bool IsStopped { get; }
+
+        /// <summary>
         /// Starts this instance.
         /// </summary>
         void Start();

--- a/SolrScheduler.Objects/Solr/SolrOperation.cs
+++ b/SolrScheduler.Objects/Solr/SolrOperation.cs
@@ -60,6 +60,18 @@ namespace SolrScheduler.Objects.Solr {
         /// <value><c>true</c> if this instance is running; otherwise, <c>false</c>.</value>
         public bool IsRunning { get; private set; }
 
+        /// <summary>
+        /// Inverse of IsRunning - primarily used to disable button in WPF grid
+        /// </summary>
+        /// <value><c>true</c> if this instance is stopped; otherwise, <c>true</c>.</value>
+        public bool IsStopped
+        {
+            get
+            {
+                return !IsRunning;
+            }
+        }
+
         #endregion
 
         /// <summary>


### PR DESCRIPTION

Disabled/Enabled stop/start buttons depending on current status of solr index. Makes it clearer to user when stop/start functionality is available.

Updated gitignore to ignore lots more commonly used build files etc.